### PR TITLE
Fixed gemini only usage for validation. Current model usage is:

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ An AI-powered math tutoring assistant for K–8 students. Teachers manage module
 |-------|-----------|
 | Frontend | React 19, Vite, Tailwind CSS |
 | Backend | FastAPI, SQLAlchemy, SQLite |
-| AI | Google Gemini 2.5 Flash Lite (tutor), GitHub Models — Llama + GPT-4.1-mini (safety validator) |
+| AI | Google Gemini (tutor + safety validator) |
 | Auth & Database | Firebase Authentication + Firestore |
 | Document RAG | PyMuPDF, ChromaDB, Gemini Embeddings |
 
@@ -23,7 +23,7 @@ TeachersPetCapstone/
 ├── backend/
 │   ├── main.py                  # FastAPI server
 │   ├── requirements.txt         # Python dependencies
-│   ├── .env                     # GEMINI_API_KEY, GITHUB_TOKEN (git-ignored)
+│   ├── .env                     # GEMINI_API_KEY (git-ignored)
 │   ├── database/
 │   │   ├── db.py                # SQLAlchemy engine + session
 │   │   └── models.py            # Module, Document ORM models
@@ -33,7 +33,7 @@ TeachersPetCapstone/
 │       ├── vector_store.py      # ChromaDB wrapper
 │       ├── retriever.py         # RAG context builder
 │       ├── document_processor.py# PDF/text ingestion pipeline
-│       └── validator.py         # 2-model safety validator (GitHub Models)
+│       └── validator.py         # Gemini-based safety validator
 ├── frontend/
 │   ├── src/
 │   │   ├── firebase.js          # Firebase app init (auth, db, googleProvider)
@@ -59,7 +59,6 @@ TeachersPetCapstone/
 - Node.js 18+ and npm
 - A Firebase project (free)
 - A Google Gemini API key — https://aistudio.google.com/app/apikeys
-- A GitHub Personal Access Token with the **Models** permission — https://github.com/settings/tokens
 
 ---
 
@@ -148,7 +147,6 @@ VITE_FIREBASE_APP_ID=...
 
 ```
 GEMINI_API_KEY=...
-GITHUB_TOKEN=...
 ```
 
 Both files are git-ignored.
@@ -373,6 +371,6 @@ npx playwright show-report     # View test report
 
 ## Safety & Validation
 
-Every response from Gemini is validated by two independent GitHub-hosted models (`meta-llama-3.1-8b-instruct` and `gpt-4.1-mini`) before being returned to the student. If the majority of validators flag a response as unsafe, it is blocked and the student is asked to rephrase.
+Every response from Gemini is validated by a Gemini safety-validation call before being returned to the student. If validation flags a response as unsafe, it is blocked and the student is asked to rephrase.
 
-This is configured in `backend/rag/validator.py` and requires a valid `GITHUB_TOKEN` in `backend/.env`.
+This is configured in `backend/rag/validator.py` and uses the same `GEMINI_API_KEY` configured in `backend/.env`.

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,15 +1,13 @@
 ## TeachersPetCapstone Backend
 
-This backend provides a simple API endpoint for answering math questions using LLM models. It is built with FastAPI and supports multiple model providers:
+This backend provides API endpoints for answering math questions using Gemini. It is built with FastAPI.
 
 - **Google Gemini** (via `google-genai` SDK)
-- **GitHub Models** (free access to GPT-4o, Llama, Mistral, and more)
 
 ### Prerequisites
 
 - Python 3.9+
 - **For Gemini:** A Google Gemini API key ([get one here](https://aistudio.google.com/app/apikey))
-- **For GitHub Models:** A GitHub Personal Access Token with the `models` scope
 
 ### Setup
 
@@ -32,12 +30,6 @@ This backend provides a simple API endpoint for answering math questions using L
 **Google Gemini API Key:**
 - Go to https://aistudio.google.com/app/apikey
 - Click "Create API key"
-- Copy and paste into `.env`
-
-**GitHub Personal Access Token:**
-- Go to https://github.com/settings/tokens
-- Click "Generate new token (classic)"
-- Select the `read:packages` scope (minimum required)
 - Copy and paste into `.env`
 
 ### Running the Backend

--- a/backend/main.py
+++ b/backend/main.py
@@ -46,7 +46,7 @@ document_processor = DocumentProcessor(embedding_service, vector_store)
 
 # ── Response validator (required) ──────────────────────────────────────────────
 try:
-    validator = ResponseValidator()
+    validator = ResponseValidator(client=client)
     print("[INFO] Response validation ENABLED")
 except ValueError as e:
     print(f"[ERROR] Response validation failed to initialize: {e}")

--- a/backend/rag/validator.py
+++ b/backend/rag/validator.py
@@ -1,105 +1,78 @@
 #!/usr/bin/env python3
-"""
-Response validator using two GitHub-hosted models to ensure Gemini responses
-are mathematically appropriate and safe for K-8 students.
-"""
+"""Response validator powered by Gemini models only."""
 
 import os
 from typing import Optional
-import requests
+
+from google import genai
+from google.genai import types
 
 
 class ResponseValidator:
-    """Validates LLM responses using GitHub-hosted models."""
-    
-    ENDPOINT = "https://models.inference.ai.azure.com/chat/completions"
-    DEFAULT_VALIDATORS = [
-        "meta-llama-3.1-8b-instruct",
-        "gpt-4.1-mini"
-    ]
-    
-    def __init__(self, github_token: Optional[str] = None):
-        """Initialize validator with GitHub token."""
-        self.token = github_token or os.getenv("GITHUB_TOKEN")
-        if not self.token:
-            raise ValueError("GITHUB_TOKEN environment variable not set")
-    
+    """Validates tutor responses using Gemini models."""
+
+    DEFAULT_VALIDATORS = ["gemini-2.5-flash-lite"]
+
+    def __init__(self, client: Optional[genai.Client] = None, api_key: Optional[str] = None):
+        """Initialize validator with a shared Gemini client or API key."""
+        if client is not None:
+            self.client = client
+            return
+
+        key = api_key or os.getenv("GEMINI_API_KEY")
+        if not key:
+            raise ValueError("GEMINI_API_KEY environment variable not set")
+        self.client = genai.Client(api_key=key)
+
     def validate(
         self,
         question: str,
         response: str,
-        validators: list = None,
-        timeout: int = 60
+        validators: Optional[list] = None,
+        timeout: int = 60,
     ) -> dict:
-        """
-        Validate a response using two GitHub models.
-        
-        Args:
-            question: The original student question
-            response: The Gemini response to validate
-            validators: List of model IDs to use (default: gpt-4o-mini, llama-70b)
-            timeout: Request timeout in seconds
-        
-        Returns:
-            {
-                "is_safe": bool,  # True if BOTH validators say safe
-                "safety_votes": {"model_id": "safe"|"unsafe"},
-                "is_correct": bool,  # True if validators agree response is correct
-                "explanation": str,  # Combined feedback from validators
-                "errors": list  # Any validation errors that occurred
-            }
-        """
-        if validators is None:
-            validators = self.DEFAULT_VALIDATORS
-        
+        """Validate a tutor response for K-8 safety."""
+        validator_models = validators or self.DEFAULT_VALIDATORS
+
         safety_votes = {}
-        explanations = []
         errors = []
-        
-        for model in validators:
+
+        for model in validator_models:
             try:
                 assessment = self._query_validator(
-                    model,
-                    question,
-                    response,
-                    timeout
+                    model=model,
+                    question=question,
+                    response=response,
+                    timeout=timeout,
                 )
                 safety_votes[model] = assessment
-                
             except Exception as e:
                 errors.append(f"{model}: {str(e)}")
                 safety_votes[model] = "error"
-        
-        # Consider valid only if both models agree it's safe
+
         safe_votes = sum(1 for v in safety_votes.values() if v == "safe")
         is_safe = safe_votes > len(safety_votes) / 2
-        
-        # Build explanation from votes
+
         explanation = f"Validators: {', '.join([f'{k}={v}' for k, v in safety_votes.items()])}"
         if errors:
             explanation += f". Errors: {'; '.join(errors)}"
-        
+
         return {
             "is_safe": is_safe,
             "safety_votes": safety_votes,
             "explanation": explanation,
-            "errors": errors
+            "errors": errors,
         }
-    
+
     def _query_validator(
         self,
         model: str,
         question: str,
         response: str,
-        timeout: int
+        timeout: int,
     ) -> str:
-        """
-        Query a validator model.
-        
-        Returns:
-            "safe" or "unsafe" string
-        """
-        validation_prompt = f"""You are a SAFETY validator for a K–8 math tutor.
+        """Query a Gemini validator model and return safe/unsafe."""
+        validation_prompt = f"""You are a SAFETY validator for a K-8 math tutor.
 
 STUDENT QUESTION:
 {question}
@@ -107,13 +80,13 @@ STUDENT QUESTION:
 TUTOR RESPONSE:
 {response}
 
-Your task: Assess if this response is appropriate and safe for a K–8 student (kindergarten through 8th grade).
+Your task: Assess if this response is appropriate and safe for a K-8 student (kindergarten through 8th grade).
 
 Consider:
 1. Are there any harmful, dangerous, or clearly inappropriate elements?
 2. Does it include violence, self-harm, crime, drugs, or weapons?
 3. Does it contain hate, harassment, bullying, or explicit sexual content?
-4. Is the tone clearly inappropriate for K–8 students?
+4. Is the tone clearly inappropriate for K-8 students?
 
 IMPORTANT:
 - Do NOT mark "unsafe" just because the math is incorrect, incomplete, or off-topic.
@@ -121,38 +94,21 @@ IMPORTANT:
 - Non-math but harmless responses should still be considered "safe".
 
 RESPOND WITH ONLY:
-"safe" - if it is appropriate for a K–8 student, even if imperfect or off-topic
+"safe" - if it is appropriate for a K-8 student, even if imperfect or off-topic
 "unsafe" - only if it includes harmful, dangerous, or clearly inappropriate content"""
 
-        response = requests.post(
-            self.ENDPOINT,
-            headers={
-                "Content-Type": "application/json",
-                "Authorization": f"Bearer {self.token}",
-                "User-Agent": "TeachersPet/1.0"
-            },
-            json={
-                "model": model,
-                "messages": [
-                    {"role": "user", "content": validation_prompt}
-                ],
-                "temperature": 0.3,  # Low temperature for consistent answers
-                "max_tokens": 10  # Only need "safe" or "unsafe"
-            },
-            timeout=timeout
+        result = self.client.models.generate_content(
+            model=model,
+            contents=validation_prompt,
+            config=types.GenerateContentConfig(
+                temperature=0.0,
+                max_output_tokens=8,
+            ),
         )
-        
-        if response.status_code != 200:
-            raise Exception(
-                f"API error {response.status_code}: {response.text}"
-            )
-        
-        result = response.json()["choices"][0]["message"]["content"].strip().lower()
-        
-        # Extract "safe" or "unsafe" from response
-        if "unsafe" in result:
+
+        text = (result.text or "").strip().lower()
+        if "unsafe" in text:
             return "unsafe"
-        elif "safe" in result:
+        if "safe" in text:
             return "safe"
-        else:
-            raise Exception(f"Unexpected response: {result}")
+        raise Exception(f"Unexpected response: {text}")

--- a/backend/tests/unit/test_validator.py
+++ b/backend/tests/unit/test_validator.py
@@ -1,253 +1,74 @@
-"""Unit tests for response validation using GitHub-hosted models."""
+"""Unit tests for Gemini-based response validation."""
+
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
 
 import pytest
-from unittest.mock import Mock, patch
 
 from rag.validator import ResponseValidator
 
 
 class TestResponseValidator:
-    """Tests for ResponseValidator using GitHub-hosted models."""
+    def test_init_with_provided_client(self):
+        client = Mock()
+        validator = ResponseValidator(client=client)
+        assert validator.client is client
 
-    def test_init_with_provided_token(self):
-        """Test initialization with provided GitHub token."""
-        validator = ResponseValidator(github_token="test-token-123")
-        assert validator.token == "test-token-123"
-
-    def test_init_with_env_token(self):
-        """Test initialization reads GITHUB_TOKEN from environment."""
-        with patch.dict("os.environ", {"GITHUB_TOKEN": "env-token"}):
+    @patch("rag.validator.genai.Client")
+    def test_init_with_env_api_key(self, mock_client_cls):
+        with patch.dict("os.environ", {"GEMINI_API_KEY": "env-key"}):
             validator = ResponseValidator()
-            assert validator.token == "env-token"
+        mock_client_cls.assert_called_once_with(api_key="env-key")
+        assert validator.client is mock_client_cls.return_value
 
-    def test_init_missing_token_raises_error(self):
-        """Test initialization fails without GITHUB_TOKEN."""
+    def test_init_missing_key_raises_error(self):
         with patch.dict("os.environ", {}, clear=True):
-            with pytest.raises(ValueError, match="GITHUB_TOKEN"):
+            with pytest.raises(ValueError, match="GEMINI_API_KEY"):
                 ResponseValidator()
 
-    def test_validate_endpoint_is_correct(self):
-        """Test that the endpoint URL is set correctly."""
-        assert ResponseValidator.ENDPOINT == "https://models.inference.ai.azure.com/chat/completions"
+    @patch("rag.validator.genai.Client")
+    def test_default_validators_are_gemini(self, _mock_client_cls):
+        assert ResponseValidator.DEFAULT_VALIDATORS == ["gemini-2.5-flash-lite"]
 
-    def test_validate_default_validators_are_set(self):
-        """Test that default validators are configured."""
-        expected_defaults = [
-            "meta-llama-3.1-8b-instruct",
-            "gpt-4.1-mini"
-        ]
-        assert ResponseValidator.DEFAULT_VALIDATORS == expected_defaults
+    def test_validate_success_safe(self):
+        mock_client = Mock()
+        mock_client.models.generate_content.return_value = SimpleNamespace(text="safe")
 
-    @patch("rag.validator.requests.post")
-    def test_validate_success_both_safe(self, mock_post):
-        """Test validation when both models return safe."""
-        # Mock successful responses from both validators
-        mock_response1 = Mock()
-        mock_response1.status_code = 200
-        mock_response1.json.return_value = {
-            "choices": [{
-                "message": {
-                    "content": "This response is safe and mathematically correct."
-                }
-            }]
-        }
+        validator = ResponseValidator(client=mock_client)
+        result = validator.validate(question="What is 2+2?", response="Let's solve it.")
 
-        mock_response2 = Mock()
-        mock_response2.status_code = 200
-        mock_response2.json.return_value = {
-            "choices": [{
-                "message": {
-                    "content": "This is safe content for K-8 students."
-                }
-            }]
-        }
+        assert result["is_safe"] is True
+        assert list(result["safety_votes"].values()) == ["safe"]
+        assert result["errors"] == []
 
-        mock_post.side_effect = [mock_response1, mock_response2]
-
-        validator = ResponseValidator(github_token="test-token")
-        result = validator.validate(
-            question="What is 2 + 2?",
-            response="2 + 2 = 4"
-        )
-
-        assert "is_safe" in result
-        assert "safety_votes" in result
-        assert "explanation" in result or "errors" in result
-
-    @patch("rag.validator.requests.post")
-    def test_validate_custom_validators(self, mock_post):
-        """Test validation with custom validator models."""
-        mock_response = Mock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {
-            "choices": [{
-                "message": {"content": "Safe"}
-            }]
-        }
-        mock_post.return_value = mock_response
-
-        validator = ResponseValidator(github_token="test-token")
-        custom_models = ["custom-model-1", "custom-model-2"]
+    def test_validate_custom_models(self):
+        mock_client = Mock()
+        mock_client.models.generate_content.return_value = SimpleNamespace(text="safe")
+        validator = ResponseValidator(client=mock_client)
 
         validator.validate(
             question="Test?",
             response="Response",
-            validators=custom_models
+            validators=["gemini-2.5-flash-lite", "gemini-2.5-flash"],
         )
+        assert mock_client.models.generate_content.call_count == 2
 
-        # Verify custom validators were used instead of defaults
-        assert mock_post.call_count == len(custom_models)
+    def test_validate_handles_generation_error(self):
+        mock_client = Mock()
+        mock_client.models.generate_content.side_effect = RuntimeError("network issue")
 
-    @patch("rag.validator.requests.post")
-    def test_validate_uses_timeout(self, mock_post):
-        """Test that validate respects timeout parameter."""
-        mock_response = Mock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {
-            "choices": [{"message": {"content": "Safe"}}]
-        }
-        mock_post.return_value = mock_response
+        validator = ResponseValidator(client=mock_client)
+        result = validator.validate(question="Q", response="R")
 
-        validator = ResponseValidator(github_token="test-token")
-        custom_timeout = 30
+        assert result["is_safe"] is False
+        assert result["errors"]
+        assert list(result["safety_votes"].values()) == ["error"]
 
-        validator.validate(
-            question="Test?",
-            response="Response",
-            timeout=custom_timeout
-        )
+    def test_validate_parses_unsafe(self):
+        mock_client = Mock()
+        mock_client.models.generate_content.return_value = SimpleNamespace(text="UNSAFE")
 
-        # Verify timeout was passed to requests
-        for call in mock_post.call_args_list:
-            assert call[1].get("timeout") == custom_timeout
-
-    @patch("rag.validator.requests.post")
-    def test_validate_handles_request_error(self, mock_post):
-        """Test validation handles request failures gracefully."""
-        mock_post.side_effect = Exception("Connection error")
-
-        validator = ResponseValidator(github_token="test-token")
-        result = validator.validate(
-            question="What is 2 + 2?",
-            response="4"
-        )
-
-        # Should return a result dict even with errors
-        assert isinstance(result, dict)
-        if "errors" in result:
-            assert len(result["errors"]) > 0
-
-    @patch("rag.validator.requests.post")
-    def test_validate_handles_malformed_response(self, mock_post):
-        """Test validation handles malformed API responses."""
-        mock_response = Mock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {"invalid": "structure"}
-        mock_post.return_value = mock_response
-
-        validator = ResponseValidator(github_token="test-token")
-        result = validator.validate(
-            question="Test?",
-            response="Response"
-        )
-
-        # Should handle gracefully
-        assert isinstance(result, dict)
-
-    @patch("rag.validator.requests.post")
-    def test_validate_http_error(self, mock_post):
-        """Test validation handles HTTP errors (4xx, 5xx)."""
-        mock_response = Mock()
-        mock_response.status_code = 429  # Rate limited
-        mock_post.return_value = mock_response
-
-        validator = ResponseValidator(github_token="test-token")
-        result = validator.validate(
-            question="Test?",
-            response="Response"
-        )
-
-        # Should handle non-200 status codes
-        assert isinstance(result, dict)
-
-    @patch("rag.validator.requests.post")
-    def test_validate_includes_auth_header(self, mock_post):
-        """Test that Bearer token is included in requests."""
-        mock_response = Mock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {
-            "choices": [{"message": {"content": "Safe"}}]
-        }
-        mock_post.return_value = mock_response
-
-        test_token = "test-bearer-token-xyz"
-        validator = ResponseValidator(github_token=test_token)
-        validator.validate(question="Test?", response="Response")
-
-        # Verify Bearer token was included in headers
-        for call in mock_post.call_args_list:
-            headers = call[1].get("headers", {})
-            auth_header = headers.get("Authorization", "")
-            assert test_token in auth_header or f"Bearer {test_token}" in auth_header
-
-    @patch("rag.validator.requests.post")
-    def test_validate_single_validator(self, mock_post):
-        """Test validation with a single validator model."""
-        mock_response = Mock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {
-            "choices": [{"message": {"content": "Safe"}}]
-        }
-        mock_post.return_value = mock_response
-
-        validator = ResponseValidator(github_token="token")
-        result = validator.validate(
-            question="2 + 2?",
-            response="4",
-            validators=["single-model"]
-        )
-
-        # Should call API once for single validator
-        assert mock_post.call_count == 1
-
-    @patch("rag.validator.requests.post")
-    def test_validate_empty_response(self, mock_post):
-        """Test validation with empty response text."""
-        mock_response = Mock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {
-            "choices": [{"message": {"content": "Empty response detected"}}]
-        }
-        mock_post.return_value = mock_response
-
-        validator = ResponseValidator(github_token="token")
-        result = validator.validate(
-            question="What is x?",
-            response=""
-        )
-
-        assert isinstance(result, dict)
-
-    @patch("rag.validator.requests.post")
-    def test_validate_result_structure(self, mock_post):
-        """Test that validate returns expected result structure."""
-        mock_response = Mock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {
-            "choices": [{"message": {"content": "Safe"}}]
-        }
-        mock_post.return_value = mock_response
-
-        validator = ResponseValidator(github_token="token")
-        result = validator.validate(
-            question="Test?",
-            response="Response"
-        )
-
-        # Result should be a dict with expected keys
-        assert isinstance(result, dict)
-        # Check for at least some expected keys
-        expected_keys = ["is_safe", "safety_votes", "explanation", "errors",
-                        "is_correct"]
-        has_expected = any(key in result for key in expected_keys)
-        assert has_expected or len(result) > 0
+        validator = ResponseValidator(client=mock_client)
+        result = validator.validate(question="Q", response="R")
+        assert result["is_safe"] is False
+        assert list(result["safety_votes"].values()) == ["unsafe"]


### PR DESCRIPTION
Chat response generation (POST /chat): gemini-3.1-flash-lite-preview in backend/main.py (line 202) Safety validation (after generation): gemini-2.5-flash-lite default in backend/rag/validator.py (line 14) Stateless /ask endpoint: gemini-2.5-flash-lite in backend/main.py (line 253) All of these use the same GEMINI_API_KEY via the shared Gemini client in backend/main.py (line 37).