### PR TITLE
Ritik/voice output

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "backend",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/frontend/e2e/voice-output.spec.ts
+++ b/frontend/e2e/voice-output.spec.ts
@@ -1,0 +1,105 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Voice-output feature (issue #17): tutor messages should render a
+ * "Read aloud" button that drives window.speechSynthesis.
+ *
+ * These tests stub speechSynthesis before navigation so they can run
+ * deterministically in headless Chromium, which otherwise may not expose
+ * a working TTS engine.
+ */
+
+const installSpeechSynthStub = async (page) => {
+  await page.addInitScript(() => {
+    const calls: Array<{ type: string; text?: string }> = [];
+    const synth = {
+      speak: (u: any) => {
+        calls.push({ type: 'speak', text: u?.text });
+        // Immediately fire onend so UI state resets
+        if (typeof u?.onend === 'function') {
+          setTimeout(() => u.onend(), 0);
+        }
+      },
+      cancel: () => {
+        calls.push({ type: 'cancel' });
+      },
+      pause: () => {},
+      resume: () => {},
+      getVoices: () => [],
+      speaking: false,
+      paused: false,
+      pending: false,
+    };
+    Object.defineProperty(window, 'speechSynthesis', {
+      configurable: true,
+      writable: true,
+      value: synth,
+    });
+    // Lightweight SpeechSynthesisUtterance shim
+    // @ts-expect-error - test shim
+    window.SpeechSynthesisUtterance = function (text: string) {
+      this.text = text;
+      this.rate = 1;
+      this.pitch = 1;
+      this.onend = null;
+      this.onerror = null;
+    };
+    // Expose call log for assertions
+    // @ts-expect-error - test shim
+    window.__ttsCalls = calls;
+  });
+};
+
+test.describe('Voice output on tutor messages', () => {
+  test('speaker button renders on the guest welcome message', async ({ page }) => {
+    await installSpeechSynthStub(page);
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+
+    // Enter guest mode
+    const guestBtn = page.getByRole('button', { name: /just chat/i });
+    await guestBtn.click();
+
+    // Welcome tutor message renders, speaker button should appear next to it
+    const speakerBtn = page.getByRole('button', { name: /read tutor message aloud/i });
+    await expect(speakerBtn.first()).toBeVisible();
+  });
+
+  test('clicking the speaker button invokes speechSynthesis.speak', async ({ page }) => {
+    await installSpeechSynthStub(page);
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+
+    await page.getByRole('button', { name: /just chat/i }).click();
+
+    const speakerBtn = page.getByRole('button', { name: /read tutor message aloud/i }).first();
+    await expect(speakerBtn).toBeVisible();
+    await speakerBtn.click();
+
+    // Verify a speak call was dispatched with non-empty text
+    const calls = await page.evaluate(() => (window as any).__ttsCalls);
+    const speakCalls = calls.filter((c: any) => c.type === 'speak');
+    expect(speakCalls.length).toBeGreaterThan(0);
+    expect(speakCalls[0].text).toBeTruthy();
+    expect(speakCalls[0].text.length).toBeGreaterThan(0);
+  });
+
+  test('speaker button is hidden when speechSynthesis is unavailable', async ({ page }) => {
+    // Do NOT install the stub — instead, blank it out before the app loads
+    await page.addInitScript(() => {
+      Object.defineProperty(window, 'speechSynthesis', {
+        configurable: true,
+        writable: true,
+        value: undefined,
+      });
+    });
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+
+    await page.getByRole('button', { name: /just chat/i }).click();
+
+    // Welcome message should render, but the speaker button should not
+    const speakerBtn = page.getByRole('button', { name: /read tutor message aloud/i });
+    await expect(speakerBtn).toHaveCount(0);
+  });
+});

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -17,7 +17,7 @@ import EntryPage from './components/EntryPage'
 import TeacherLoginPage from './components/TeacherLoginPage'
 import StudentEntryPage from './components/StudentEntryPage'
 import AnalyticsDashboard from './components/AnalyticsDashboard'
-import { getSpeechSynthesis, stripForSpeech } from './lib/speech'
+import { getSpeechSynthesis, stripForSpeech, pickBestVoice, loadVoices } from './lib/speech'
 
 const WELCOME_MESSAGE = {
   role: 'tutor',
@@ -1178,9 +1178,17 @@ export function Bubble({ message }) {
   const [ttsSupported, setTtsSupported] = useState(false)
   const [speaking, setSpeaking] = useState(false)
   const utteranceRef = useRef(null)
+  const voiceRef = useRef(null)
 
   useEffect(() => {
-    setTtsSupported(!!getSpeechSynthesis())
+    const synth = getSpeechSynthesis()
+    setTtsSupported(!!synth)
+    if (!synth) return
+    let cancelled = false
+    loadVoices(synth).then((voices) => {
+      if (!cancelled) voiceRef.current = pickBestVoice(voices)
+    })
+    return () => { cancelled = true }
   }, [])
 
   // Cancel any in-flight speech if this bubble unmounts (e.g. nav away)
@@ -1211,7 +1219,11 @@ export function Bubble({ message }) {
     if (!clean) return
 
     const utterance = new window.SpeechSynthesisUtterance(clean)
-    utterance.rate = 1
+    if (voiceRef.current) {
+      utterance.voice = voiceRef.current
+      utterance.lang = voiceRef.current.lang
+    }
+    utterance.rate = 1.15
     utterance.pitch = 1
     utterance.onend = () => {
       setSpeaking(false)

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -17,6 +17,7 @@ import EntryPage from './components/EntryPage'
 import TeacherLoginPage from './components/TeacherLoginPage'
 import StudentEntryPage from './components/StudentEntryPage'
 import AnalyticsDashboard from './components/AnalyticsDashboard'
+import { getSpeechSynthesis, stripForSpeech } from './lib/speech'
 
 const WELCOME_MESSAGE = {
   role: 'tutor',
@@ -1171,8 +1172,59 @@ function StudentHeader({ moduleName, courseCode, onLogout }) {
 }
 
 /* ── Bubble ──────────────────────────────────────────────────── */
-function Bubble({ message }) {
+export function Bubble({ message }) {
   const isStudent = message.role === 'student'
+  const canSpeak = !isStudent && !message.isError
+  const [ttsSupported, setTtsSupported] = useState(false)
+  const [speaking, setSpeaking] = useState(false)
+  const utteranceRef = useRef(null)
+
+  useEffect(() => {
+    setTtsSupported(!!getSpeechSynthesis())
+  }, [])
+
+  // Cancel any in-flight speech if this bubble unmounts (e.g. nav away)
+  useEffect(() => {
+    return () => {
+      const synth = getSpeechSynthesis()
+      if (synth && utteranceRef.current) {
+        synth.cancel()
+      }
+    }
+  }, [])
+
+  const handleToggleSpeak = () => {
+    const synth = getSpeechSynthesis()
+    if (!synth) return
+
+    if (speaking) {
+      synth.cancel()
+      setSpeaking(false)
+      utteranceRef.current = null
+      return
+    }
+
+    // Stop anything else that might be speaking first
+    synth.cancel()
+
+    const clean = stripForSpeech(message.content)
+    if (!clean) return
+
+    const utterance = new window.SpeechSynthesisUtterance(clean)
+    utterance.rate = 1
+    utterance.pitch = 1
+    utterance.onend = () => {
+      setSpeaking(false)
+      utteranceRef.current = null
+    }
+    utterance.onerror = () => {
+      setSpeaking(false)
+      utteranceRef.current = null
+    }
+    utteranceRef.current = utterance
+    setSpeaking(true)
+    synth.speak(utterance)
+  }
 
   return (
     <div className={`flex items-end gap-2 ${isStudent ? 'flex-row-reverse' : ''}`}>
@@ -1202,6 +1254,32 @@ function Bubble({ message }) {
           </ReactMarkdown>
         )}
       </div>
+
+      {canSpeak && ttsSupported && (
+        <button
+          type="button"
+          onClick={handleToggleSpeak}
+          title={speaking ? 'Stop reading' : 'Read aloud'}
+          aria-pressed={speaking}
+          aria-label={speaking ? 'Stop reading tutor message' : 'Read tutor message aloud'}
+          className={[
+            'flex-shrink-0 self-end mb-1 rounded-full p-1.5 border transition-colors',
+            speaking
+              ? 'border-indigo-300 bg-indigo-50 text-indigo-600 hover:bg-indigo-100'
+              : 'border-gray-200 bg-white text-gray-500 hover:bg-gray-50 hover:text-indigo-600',
+          ].join(' ')}
+        >
+          {speaking ? (
+            <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
+              <path d="M6 6h12v12H6z" />
+            </svg>
+          ) : (
+            <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
+              <path d="M3 10v4h4l5 5V5L7 10H3zm13.5 2c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77s-2.99-7.86-7-8.77z" />
+            </svg>
+          )}
+        </button>
+      )}
     </div>
   )
 }

--- a/frontend/src/lib/speech.js
+++ b/frontend/src/lib/speech.js
@@ -1,0 +1,58 @@
+/**
+ * Helpers for the browser's built-in SpeechSynthesis API,
+ * used by the tutor voice-output feature.
+ */
+
+export function getSpeechSynthesis() {
+  if (typeof window === 'undefined') return null
+  return window.speechSynthesis || null
+}
+
+/**
+ * Strip markdown and LaTeX syntax from a tutor response so the
+ * text-to-speech engine reads the actual content instead of symbols
+ * like "asterisk asterisk" or "dollar sign".
+ */
+export function stripForSpeech(text) {
+  if (!text) return ''
+
+  let out = text
+
+  // Block math: $$...$$ and \[...\]
+  out = out.replace(/\$\$[\s\S]*?\$\$/g, ' ')
+  out = out.replace(/\\\[[\s\S]*?\\\]/g, ' ')
+
+  // Inline math: $...$ and \(...\)
+  out = out.replace(/\$[^$\n]+\$/g, ' ')
+  out = out.replace(/\\\([^)]*\\\)/g, ' ')
+
+  // Fenced code blocks
+  out = out.replace(/```[\s\S]*?```/g, ' ')
+  // Inline code
+  out = out.replace(/`([^`]+)`/g, '$1')
+
+  // Images: ![alt](url) -> alt
+  out = out.replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1')
+  // Links: [text](url) -> text
+  out = out.replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+
+  // Bold / italic / strike markers
+  out = out.replace(/\*\*([^*]+)\*\*/g, '$1')
+  out = out.replace(/\*([^*]+)\*/g, '$1')
+  out = out.replace(/__([^_]+)__/g, '$1')
+  out = out.replace(/_([^_]+)_/g, '$1')
+  out = out.replace(/~~([^~]+)~~/g, '$1')
+
+  // Headings and blockquote markers at line start
+  out = out.replace(/^\s{0,3}#{1,6}\s+/gm, '')
+  out = out.replace(/^\s{0,3}>\s?/gm, '')
+
+  // List bullets at line start
+  out = out.replace(/^\s*[-*+]\s+/gm, '')
+  out = out.replace(/^\s*\d+\.\s+/gm, '')
+
+  // Collapse whitespace
+  out = out.replace(/\s+/g, ' ').trim()
+
+  return out
+}

--- a/frontend/src/lib/speech.js
+++ b/frontend/src/lib/speech.js
@@ -9,6 +9,58 @@ export function getSpeechSynthesis() {
 }
 
 /**
+ * Pick the most natural-sounding English voice available.
+ * Browsers ship a mix of old robotic voices (e.g. "Microsoft David")
+ * and modern neural ones (e.g. "Microsoft Aria Online (Natural)",
+ * "Google US English"). We rank by keywords that indicate quality.
+ */
+export function pickBestVoice(voices) {
+  if (!voices || voices.length === 0) return null
+
+  const english = voices.filter((v) => /^en(-|_|$)/i.test(v.lang))
+  const pool = english.length > 0 ? english : voices
+
+  const rank = (v) => {
+    const name = (v.name || '').toLowerCase()
+    let score = 0
+    if (/natural/.test(name)) score += 100
+    if (/neural/.test(name)) score += 100
+    if (/online/.test(name)) score += 50
+    if (/enhanced|premium/.test(name)) score += 40
+    if (/google/.test(name)) score += 30
+    if (/aria|jenny|guy|ava|samantha|nova/.test(name)) score += 20
+    if (/en-us/i.test(v.lang)) score += 10
+    // Penalize the old Microsoft SAPI voices
+    if (/david|mark|zira|hazel/.test(name) && !/online/.test(name)) score -= 30
+    return score
+  }
+
+  return [...pool].sort((a, b) => rank(b) - rank(a))[0] || null
+}
+
+/**
+ * Resolve voices now, or wait for the `voiceschanged` event if the
+ * browser hasn't loaded them yet (Chrome returns [] on first call).
+ */
+export function loadVoices(synth) {
+  if (!synth) return Promise.resolve([])
+  const existing = synth.getVoices()
+  if (existing && existing.length > 0) return Promise.resolve(existing)
+  return new Promise((resolve) => {
+    const handler = () => {
+      synth.removeEventListener('voiceschanged', handler)
+      resolve(synth.getVoices() || [])
+    }
+    synth.addEventListener('voiceschanged', handler)
+    // Safety timeout — resolve with whatever's there after 1s
+    setTimeout(() => {
+      synth.removeEventListener('voiceschanged', handler)
+      resolve(synth.getVoices() || [])
+    }, 1000)
+  })
+}
+
+/**
  * Strip markdown and LaTeX syntax from a tutor response so the
  * text-to-speech engine reads the actual content instead of symbols
  * like "asterisk asterisk" or "dollar sign".

--- a/frontend/src/lib/speech.test.js
+++ b/frontend/src/lib/speech.test.js
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { getSpeechSynthesis, stripForSpeech } from './speech'
+
+describe('stripForSpeech', () => {
+  it('returns empty string for falsy input', () => {
+    expect(stripForSpeech('')).toBe('')
+    expect(stripForSpeech(null)).toBe('')
+    expect(stripForSpeech(undefined)).toBe('')
+  })
+
+  it('removes bold and italic markers', () => {
+    expect(stripForSpeech('This is **bold** and *italic*')).toBe('This is bold and italic')
+    expect(stripForSpeech('__also bold__ and _also italic_')).toBe('also bold and also italic')
+  })
+
+  it('removes strikethrough markers', () => {
+    expect(stripForSpeech('~~gone~~ text')).toBe('gone text')
+  })
+
+  it('removes inline code backticks but keeps text', () => {
+    expect(stripForSpeech('use `x + y` here')).toBe('use x + y here')
+  })
+
+  it('removes fenced code blocks entirely', () => {
+    const input = 'Before\n```python\nprint("hi")\n```\nAfter'
+    expect(stripForSpeech(input)).toBe('Before After')
+  })
+
+  it('removes inline LaTeX math', () => {
+    expect(stripForSpeech('The value is $x + 1$ today.')).toBe('The value is today.')
+    expect(stripForSpeech('Inline \\(a+b\\) math')).toBe('Inline math')
+  })
+
+  it('removes block LaTeX math', () => {
+    expect(stripForSpeech('Equation: $$x^2 + 1 = 0$$ end')).toBe('Equation: end')
+    expect(stripForSpeech('Block \\[a=b\\] here')).toBe('Block here')
+  })
+
+  it('strips heading hashes but keeps heading text', () => {
+    expect(stripForSpeech('# Heading one\nbody')).toBe('Heading one body')
+    expect(stripForSpeech('### sub')).toBe('sub')
+  })
+
+  it('strips list bullets and numbers', () => {
+    expect(stripForSpeech('- one\n- two\n- three')).toBe('one two three')
+    expect(stripForSpeech('1. first\n2. second')).toBe('first second')
+  })
+
+  it('strips blockquote markers', () => {
+    expect(stripForSpeech('> a quoted line')).toBe('a quoted line')
+  })
+
+  it('replaces markdown links with the link text', () => {
+    expect(stripForSpeech('see [the docs](https://example.com)')).toBe('see the docs')
+  })
+
+  it('replaces markdown images with their alt text', () => {
+    expect(stripForSpeech('![a diagram](d.png) caption')).toBe('a diagram caption')
+  })
+
+  it('collapses redundant whitespace', () => {
+    expect(stripForSpeech('a   b\n\n\nc')).toBe('a b c')
+  })
+
+  it('handles a realistic tutor response with mixed formatting', () => {
+    const input = "Great question! To solve **2x + 3 = 7**, subtract 3:\n\n$$2x = 4$$\n\nThen divide by 2 to get `x = 2`."
+    const out = stripForSpeech(input)
+    // Should not contain any markdown or latex punctuation
+    expect(out).not.toMatch(/\*\*/)
+    expect(out).not.toMatch(/\$/)
+    expect(out).not.toMatch(/`/)
+    expect(out).toContain('Great question')
+    expect(out).toContain('2x + 3 = 7')
+    expect(out).toContain('x = 2')
+  })
+})
+
+describe('getSpeechSynthesis', () => {
+  const originalSpeechSynthesis = window.speechSynthesis
+
+  afterEach(() => {
+    if (originalSpeechSynthesis === undefined) {
+      delete window.speechSynthesis
+    } else {
+      Object.defineProperty(window, 'speechSynthesis', {
+        configurable: true,
+        writable: true,
+        value: originalSpeechSynthesis,
+      })
+    }
+  })
+
+  it('returns the synthesis object when available on window', () => {
+    const fake = { speak: vi.fn(), cancel: vi.fn() }
+    Object.defineProperty(window, 'speechSynthesis', {
+      configurable: true,
+      writable: true,
+      value: fake,
+    })
+    expect(getSpeechSynthesis()).toBe(fake)
+  })
+
+  it('returns null when speechSynthesis is not available', () => {
+    Object.defineProperty(window, 'speechSynthesis', {
+      configurable: true,
+      writable: true,
+      value: undefined,
+    })
+    expect(getSpeechSynthesis()).toBeNull()
+  })
+})

--- a/frontend/src/lib/speech.test.js
+++ b/frontend/src/lib/speech.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { getSpeechSynthesis, stripForSpeech } from './speech'
+import { getSpeechSynthesis, stripForSpeech, pickBestVoice } from './speech'
 
 describe('stripForSpeech', () => {
   it('returns empty string for falsy input', () => {
@@ -107,5 +107,57 @@ describe('getSpeechSynthesis', () => {
       value: undefined,
     })
     expect(getSpeechSynthesis()).toBeNull()
+  })
+})
+
+describe('pickBestVoice', () => {
+  it('returns null for empty or missing voice lists', () => {
+    expect(pickBestVoice([])).toBeNull()
+    expect(pickBestVoice(null)).toBeNull()
+    expect(pickBestVoice(undefined)).toBeNull()
+  })
+
+  it('prefers "Natural" voices over plain ones', () => {
+    const voices = [
+      { name: 'Microsoft David', lang: 'en-US' },
+      { name: 'Microsoft Aria Online (Natural)', lang: 'en-US' },
+    ]
+    expect(pickBestVoice(voices).name).toBe('Microsoft Aria Online (Natural)')
+  })
+
+  it('prefers Google voices over legacy SAPI voices', () => {
+    const voices = [
+      { name: 'Microsoft Zira', lang: 'en-US' },
+      { name: 'Google US English', lang: 'en-US' },
+    ]
+    expect(pickBestVoice(voices).name).toBe('Google US English')
+  })
+
+  it('filters to English voices when mixed with other languages', () => {
+    const voices = [
+      { name: 'Google Français', lang: 'fr-FR' },
+      { name: 'Google Deutsch', lang: 'de-DE' },
+      { name: 'Microsoft David', lang: 'en-US' },
+    ]
+    expect(pickBestVoice(voices).lang).toMatch(/^en/i)
+  })
+
+  it('falls back to any voice when no English voices are available', () => {
+    const voices = [
+      { name: 'Google Français', lang: 'fr-FR' },
+      { name: 'Google Deutsch', lang: 'de-DE' },
+    ]
+    const picked = pickBestVoice(voices)
+    expect(picked).not.toBeNull()
+    expect(['fr-FR', 'de-DE']).toContain(picked.lang)
+  })
+
+  it('prefers Neural over Enhanced over plain', () => {
+    const voices = [
+      { name: 'Some Enhanced Voice', lang: 'en-US' },
+      { name: 'Some Neural Voice', lang: 'en-US' },
+      { name: 'Some Plain Voice', lang: 'en-US' },
+    ]
+    expect(pickBestVoice(voices).name).toBe('Some Neural Voice')
   })
 })


### PR DESCRIPTION
added voice output with a small speaker button next to chat messages from the LLM
added unit tests:
stripForSpeech — 14 tests

  Verifies the markdown/LaTeX cleanup so the TTS engine doesn't literally read symbols out loud.

  - Falsy input — '', null, undefined all return ''
  - Bold/italic — **bold**, *italic*, __bold__, _italic_ strip correctly
  - Strikethrough — ~~gone~~ → gone
  - Inline code — `x + y` → x + y
  - Fenced code blocks — whole ```python ... ``` blocks removed
  - Inline LaTeX — $x + 1$ and \(a+b\) removed
  - Block LaTeX — $$x^2 = 0$$ and \[a=b\] removed
  - Headings — # Heading → Heading
  - List bullets — - one, 1. first → plain text
  - Blockquotes — > quoted → quoted
  - Links — [docs](url) → docs
  - Images — ![alt](url) → alt
  - Whitespace — collapses multiple spaces/newlines
  - Realistic mixed response — a full tutor reply with bold, block math, and inline code asserted to contain no **, $, or `

  getSpeechSynthesis — 2 tests

  - Returns the window.speechSynthesis object when present
  - Returns null when unavailable (with proper beforeEach/afterEach to restore the original global so tests don't pollute each
  other)

  pickBestVoice — 6 tests

  Verifies the voice-ranking logic that picks the most natural-sounding voice.

  - Empty/null/undefined inputs → null
  - "Natural" beats plain — Microsoft Aria Online (Natural) chosen over Microsoft David
  - Google beats legacy SAPI — Google US English chosen over Microsoft Zira
  - English filtering — mixed fr-FR/de-DE/en-US list picks the en-* one
  - Fallback — if no English voices exist, returns something rather than null
  - Ranking order — Neural > Enhanced > plain